### PR TITLE
feat(template-variables): Response body and header should be able to parse template

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -9,6 +9,7 @@
     "api-endpoint-data-access": "libs/api/endpoint/data-access",
     "api-endpoint-feature": "libs/api/endpoint/feature",
     "api-intercept-feature": "libs/api/intercept/feature",
+    "api-intercept-utils": "libs/api/intercept/utils",
     "api-project-data-access": "libs/api/project/data-access",
     "api-project-feature": "libs/api/project/feature",
     "api-project-utils": "libs/api/project/utils",

--- a/libs/api/intercept/feature/src/lib/api-intercept-feature.controller.ts
+++ b/libs/api/intercept/feature/src/lib/api-intercept-feature.controller.ts
@@ -4,7 +4,7 @@ import sleep from 'sleep-promise';
 import { Project, ProjectConfiguration } from '@prisma/client';
 import { EndpointService } from '@aymme/api/endpoint/data-access';
 import { CurrentProject, ProjectGuard } from '@aymme/api/project/utils';
-import { interpolateTemplateString } from './interpolate-template';
+import { interpolateTemplateString } from '@aymme/api/intercept/utils';
 
 @Controller('intercept')
 export class ApiInterceptFeatureController {

--- a/libs/api/intercept/utils/.eslintrc.json
+++ b/libs/api/intercept/utils/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "aymme",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "aymme",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/api/intercept/utils/README.md
+++ b/libs/api/intercept/utils/README.md
@@ -1,0 +1,7 @@
+# api-intercept-utils
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test api-intercept-utils` to execute the unit tests.

--- a/libs/api/intercept/utils/jest.config.js
+++ b/libs/api/intercept/utils/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  displayName: 'api-intercept-utils',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/api/intercept/utils',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/api/intercept/utils/project.json
+++ b/libs/api/intercept/utils/project.json
@@ -1,0 +1,23 @@
+{
+  "projectType": "library",
+  "root": "libs/api/intercept/utils",
+  "sourceRoot": "libs/api/intercept/utils/src",
+  "prefix": "aymme",
+  "architect": {
+    "test": {
+      "builder": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/api/intercept/utils"],
+      "options": {
+        "jestConfig": "libs/api/intercept/utils/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "builder": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["libs/api/intercept/utils/src/**/*.ts", "libs/api/intercept/utils/src/**/*.html"]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/api/intercept/utils/src/index.ts
+++ b/libs/api/intercept/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/interpolate/interpolate-template';

--- a/libs/api/intercept/utils/src/lib/interpolate/interpolate-template.ts
+++ b/libs/api/intercept/utils/src/lib/interpolate/interpolate-template.ts
@@ -4,8 +4,8 @@
  * @param variables {firstName: 'John'}
  * @return 'hi, John'
  **/
-export function interpolateTemplateString(template, variables) {
-  return template.replace(/\{\{[^{}]+\}\}/g, function(templateWithBrackets) {
+export function interpolateTemplateString(template: string, variables: any): string {
+  return template.replace(/\{\{[^{}]+\}\}/g, function(templateWithBrackets: string) {
     const key = templateWithBrackets.slice(2, templateWithBrackets.length - 2);
     return variables[key] ?? templateWithBrackets;
   })

--- a/libs/api/intercept/utils/src/test-setup.ts
+++ b/libs/api/intercept/utils/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/api/intercept/utils/tsconfig.json
+++ b/libs/api/intercept/utils/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/api/intercept/utils/tsconfig.lib.json
+++ b/libs/api/intercept/utils/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/api/intercept/utils/tsconfig.spec.json
+++ b/libs/api/intercept/utils/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -14,13 +14,7 @@
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e",
-          "build-storybook"
-        ],
+        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"],
         "parallel": 1
       }
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@aymme/api/endpoint/data-access": ["libs/api/endpoint/data-access/src/index.ts"],
       "@aymme/api/endpoint/feature": ["libs/api/endpoint/feature/src/index.ts"],
       "@aymme/api/intercept/feature": ["libs/api/intercept/feature/src/index.ts"],
+      "@aymme/api/intercept/utils": ["libs/api/intercept/utils/src/index.ts"],
       "@aymme/api/project/data-access": ["libs/api/project/data-access/src/index.ts"],
       "@aymme/api/project/feature": ["libs/api/project/feature/src/index.ts"],
       "@aymme/api/project/utils": ["libs/api/project/utils/src/index.ts"],


### PR DESCRIPTION
Issue #54 

- User can use `{{some_variable}}` in header and body
- Variables are hard coded for now `{firstName: 'Kern', lastName: 'Zhao'}`, this will be moved to DB and configured by user.

![image](https://user-images.githubusercontent.com/15252454/157525398-f4e93a58-17aa-47c4-bb50-c7beee6b293d.png)
Response:
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/15252454/157526012-5ea981bf-4e99-4289-990e-b4d1add4ae30.png">

